### PR TITLE
Added support for explicitly specifying aspect ratio

### DIFF
--- a/Sources/ImageViewer/ImageViewer.swift
+++ b/Sources/ImageViewer/ImageViewer.swift
@@ -7,19 +7,23 @@ public struct ImageViewer: View {
     @Binding var image: Image
     @Binding var imageOpt: Image?
     
+    var aspectRatio: Binding<CGFloat>?
+    
     @State var dragOffset: CGSize = CGSize.zero
     @State var dragOffsetPredicted: CGSize = CGSize.zero
     
-    public init(image: Binding<Image>, viewerShown: Binding<Bool>) {
+    public init(image: Binding<Image>, viewerShown: Binding<Bool>, aspectRatio: Binding<CGFloat>? = nil) {
         _image = image
         _viewerShown = viewerShown
         _imageOpt = .constant(nil)
+        self.aspectRatio = aspectRatio
     }
     
-    public init(image: Binding<Image?>, viewerShown: Binding<Bool>) {
+    public init(image: Binding<Image?>, viewerShown: Binding<Bool>, aspectRatio: Binding<CGFloat>? = nil) {
         _image = .constant(Image(systemName: ""))
         _imageOpt = image
         _viewerShown = viewerShown
+        self.aspectRatio = aspectRatio
     }
     
     func getImage() -> Image {
@@ -55,7 +59,7 @@ public struct ImageViewer: View {
                     VStack {
                         self.getImage()
                             .resizable()
-                            .aspectRatio(contentMode: .fit)
+                            .aspectRatio(self.aspectRatio?.wrappedValue, contentMode: .fit)
                             .offset(x: self.dragOffset.width, y: self.dragOffset.height)
                             .rotationEffect(.init(degrees: Double(self.dragOffset.width / 30)))
                             .pinchToZoom()
@@ -65,10 +69,6 @@ public struct ImageViewer: View {
                                 self.dragOffsetPredicted = value.predictedEndTranslation
                             }
                             .onEnded { value in
-                                print(abs(self.dragOffset.height) + abs(self.dragOffset.width))
-                                print((abs(self.dragOffsetPredicted.height)) / (abs(self.dragOffset.height)))
-                                print((abs(self.dragOffsetPredicted.width)) / (abs(self.dragOffset.width)))
-                                
                                 if((abs(self.dragOffset.height) + abs(self.dragOffset.width) > 570) || ((abs(self.dragOffsetPredicted.height)) / (abs(self.dragOffset.height)) > 3) || ((abs(self.dragOffsetPredicted.width)) / (abs(self.dragOffset.width))) > 3) {
                                     self.viewerShown = false
                                     

--- a/Sources/ImageViewerRemote/ImageViewerRemote.swift
+++ b/Sources/ImageViewerRemote/ImageViewerRemote.swift
@@ -8,13 +8,16 @@ public struct ImageViewerRemote: View {
     @Binding var imageURL: String
     @State var httpHeaders: [String: String]?
     
+    var aspectRatio: Binding<CGFloat>?
+    
     @State var dragOffset: CGSize = CGSize.zero
     @State var dragOffsetPredicted: CGSize = CGSize.zero
     
-    public init(imageURL: Binding<String>, viewerShown: Binding<Bool>, httpHeaders: [String: String]? = nil) {
+    public init(imageURL: Binding<String>, viewerShown: Binding<Bool>, httpHeaders: [String: String]? = nil, aspectRatio: Binding<CGFloat>? = nil) {
         _imageURL = imageURL
         _viewerShown = viewerShown
         _httpHeaders = State(initialValue: httpHeaders)
+        self.aspectRatio = aspectRatio
     }
     
     func getURLRequest(url: String, headers: [String: String]?) -> URLRequest {
@@ -62,7 +65,7 @@ public struct ImageViewerRemote: View {
                         URLImage(getURLRequest(url: self.imageURL, headers: self.httpHeaders)) { proxy in
                         proxy.image
                             .resizable()
-                            .aspectRatio(contentMode: .fit)
+                            .aspectRatio(self.aspectRatio?.wrappedValue, contentMode: .fit)
                             .offset(x: self.dragOffset.width, y: self.dragOffset.height)
                             .rotationEffect(.init(degrees: Double(self.dragOffset.width / 30)))
                             .pinchToZoom()


### PR DESCRIPTION
Explicitly specifying an aspect ratio fixes an issue on iOS 13 where the image may get incorrectly stretched (as seen in #9). Specifying the aspect ratio is not needed much of the time, and the issue is fixed in most (if not all) cases on iOS 14.