### PR TITLE
Fix url image dependency (2.0.0 update)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/dmytro-anokhin/url-image.git",
         "state": {
           "branch": null,
-          "revision": "22eca5ee4f317e0283da75426849ee23f0516022",
-          "version": "0.9.19"
+          "revision": "cedfdb207dcba2aec1229f3e2053bb93460a4244",
+          "version": "2.1.9"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/dmytro-anokhin/url-image.git", from: "0.9.15")
+        .package(url: "https://github.com/dmytro-anokhin/url-image.git", from: "2.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -65,29 +65,6 @@ struct ContentView: View {
 
 # Customization
 
-### HTTP Headers
-
-#### Availability: 1.0.15 or higher
-
-The remote image viewer allows HTTP headers to be included in the URL request. To use them, pass a dictonary to the httpHeaders field. The format should be [Header: Value], both strings.
-
-Example:
-```Swift
-import ImageViewerRemote
-
-struct ContentView: View {
-    @State var showImageViewer: Bool = true
-	
-    var body: some View {
-        VStack {
-            Text("Example!")
-        }
-	.frame(maxWidth: .infinity, maxHeight: .infinity)
-        .overlay(ImageViewerRemote(imageURL: URL(string: "https://..."), viewerShown: self.$showImageViewer, httpHeaders: ["X-Powered-By": "Swift!"]))
-    }
-}
-```
-
 ### Explicit Aspect Ratio
 
 #### Availability: 1.0.21 or higher
@@ -131,6 +108,30 @@ struct ContentView: View {
         }
 	.frame(maxWidth: .infinity, maxHeight: .infinity)
         .overlay(ImageViewerRemote(imageURL: URL(string: "https://..."), viewerShown: self.$showImageViewer, disableCache: true))
+    }
+}
+```
+
+### HTTP Headers
+
+#### Availability: 1.0.15 to 1.0.25
+#### *DEPRECATED*: No longer available as of 2.0.0
+
+The remote image viewer allows HTTP headers to be included in the URL request. To use them, pass a dictonary to the httpHeaders field. The format should be [Header: Value], both strings.
+
+Example:
+```Swift
+import ImageViewerRemote
+
+struct ContentView: View {
+    @State var showImageViewer: Bool = true
+	
+    var body: some View {
+        VStack {
+            Text("Example!")
+        }
+	.frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay(ImageViewerRemote(imageURL: URL(string: "https://..."), viewerShown: self.$showImageViewer, httpHeaders: ["X-Powered-By": "Swift!"]))
     }
 }
 ```


### PR DESCRIPTION
Addresses #16 

**Notes:**
- Newest version of URL-Image package dependency removes the URLRequest parameter option, and now only takes a URL. This removes the ability to add custom HTTP headers, so that has been deprecated.