### PR TITLE
Added ability to move close button to top right

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,30 @@ struct ContentView: View {
 
 # Customization
 
+### Close Button Position
+
+#### Availability: 2.2.0 or higher
+
+The close button can be moved to the top right if desired. The `closeButtonTopRight` parameter accepts `bool`.
+
+Example:
+```Swift
+import ImageViewer
+
+struct ContentView: View {
+    @State var showImageViewer: Bool = true
+    @State var image = Image("example-image")
+    
+    var body: some View {
+        VStack {
+            Text("Example!")
+        }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay(ImageViewer(image: self.$image, viewerShown: self.$showImageViewer, closeButtonTopRight: true))
+    }
+}
+```
+
 
 ### Caption
 

--- a/Sources/ImageViewer/ImageViewer.swift
+++ b/Sources/ImageViewer/ImageViewer.swift
@@ -7,26 +7,29 @@ public struct ImageViewer: View {
     @Binding var image: Image
     @Binding var imageOpt: Image?
     @State var caption: Text?
+    @State var closeButtonTopRight: Bool?
     
     var aspectRatio: Binding<CGFloat>?
     
     @State var dragOffset: CGSize = CGSize.zero
     @State var dragOffsetPredicted: CGSize = CGSize.zero
     
-    public init(image: Binding<Image>, viewerShown: Binding<Bool>, aspectRatio: Binding<CGFloat>? = nil, caption: Text? = nil) {
+    public init(image: Binding<Image>, viewerShown: Binding<Bool>, aspectRatio: Binding<CGFloat>? = nil, caption: Text? = nil, closeButtonTopRight: Bool? = false) {
         _image = image
         _viewerShown = viewerShown
         _imageOpt = .constant(nil)
         self.aspectRatio = aspectRatio
         _caption = State(initialValue: caption)
+        _closeButtonTopRight = State(initialValue: closeButtonTopRight)
     }
     
-    public init(image: Binding<Image?>, viewerShown: Binding<Bool>, aspectRatio: Binding<CGFloat>? = nil, caption: Text? = nil) {
+    public init(image: Binding<Image?>, viewerShown: Binding<Bool>, aspectRatio: Binding<CGFloat>? = nil, caption: Text? = nil, closeButtonTopRight: Bool? = false) {
         _image = .constant(Image(systemName: ""))
         _imageOpt = image
         _viewerShown = viewerShown
         self.aspectRatio = aspectRatio
         _caption = State(initialValue: caption)
+        _closeButtonTopRight = State(initialValue: closeButtonTopRight)
     }
     
     func getImage() -> Image {
@@ -45,13 +48,20 @@ public struct ImageViewer: View {
                 ZStack {
                     VStack {
                         HStack {
+                            
+                            if self.closeButtonTopRight == true {
+                                Spacer()
+                            }
+                            
                             Button(action: { self.viewerShown = false }) {
                                 Image(systemName: "xmark")
                                     .foregroundColor(Color(UIColor.white))
                                     .font(.system(size: UIFontMetrics.default.scaledValue(for: 24)))
                             }
                             
-                            Spacer()
+                            if self.closeButtonTopRight != true {
+                                Spacer()
+                            }
                         }
                         
                         Spacer()

--- a/Sources/ImageViewerRemote/ImageViewerRemote.swift
+++ b/Sources/ImageViewerRemote/ImageViewerRemote.swift
@@ -10,6 +10,7 @@ public struct ImageViewerRemote: View {
     @State var httpHeaders: [String: String]?
     @State var disableCache: Bool?
     @State var caption: Text?
+    @State var closeButtonTopRight: Bool?
     
     var aspectRatio: Binding<CGFloat>?
     
@@ -18,12 +19,13 @@ public struct ImageViewerRemote: View {
     
     @ObservedObject var loader: ImageLoader
     
-    public init(imageURL: Binding<String>, viewerShown: Binding<Bool>, aspectRatio: Binding<CGFloat>? = nil, disableCache: Bool? = nil, caption: Text? = nil) {
+    public init(imageURL: Binding<String>, viewerShown: Binding<Bool>, aspectRatio: Binding<CGFloat>? = nil, disableCache: Bool? = nil, caption: Text? = nil, closeButtonTopRight: Bool? = false) {
         _imageURL = imageURL
         _viewerShown = viewerShown
         _disableCache = State(initialValue: disableCache)
         self.aspectRatio = aspectRatio
         _caption = State(initialValue: caption)
+        _closeButtonTopRight = State(initialValue: closeButtonTopRight)
         
         loader = ImageLoader(url: imageURL)
     }
@@ -35,13 +37,21 @@ public struct ImageViewerRemote: View {
                 ZStack {
                     VStack {
                         HStack {
+                              
+                            if self.closeButtonTopRight == true {
+                                Spacer()
+                            }
+                            
                             Button(action: { self.viewerShown = false }) {
                                 Image(systemName: "xmark")
                                     .foregroundColor(Color(UIColor.white))
                                     .font(.system(size: UIFontMetrics.default.scaledValue(for: 24)))
                             }
                             
-                            Spacer()
+                            
+                            if self.closeButtonTopRight != true {
+                                Spacer()
+                            }
                         }
                         
                         Spacer()


### PR DESCRIPTION
Fixes #24 

- Adds ability to move close button to top right with optional parameter `closeButtonTopRight`, which accepts `bool`.