### PR TITLE
UIKit import was not necessary removed

### DIFF
--- a/Sources/ImageViewer/ImageViewer.swift
+++ b/Sources/ImageViewer/ImageViewer.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 @available(iOS 13.0, *)
 public struct ImageViewer: View {

--- a/Sources/ImageViewerRemote/ImageViewerRemote.swift
+++ b/Sources/ImageViewerRemote/ImageViewerRemote.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 import URLImage
 import Combine
 


### PR DESCRIPTION
The UIKit import prevents the full SwiftUI MACOS application. I noticed that the import was not necessary, so removed and tested it!